### PR TITLE
Fix keyboard input pane bugs with prompts

### DIFF
--- a/muddler
+++ b/muddler
@@ -3765,7 +3765,7 @@ sub update_input_offset
 
    $plen = ansi_length(prompt()) + 1 if(has_prompt());
    my $lines = sprintf("%d",(line_pos() + $plen )/ (@state{size_y}-1));
-   $lines++ if((line_pos() + $plen) % (@state{size_y}-1) >= 0);
+   $lines++ if((line_pos() + $plen) % (@state{size_y}-1) > 0);
    $lines = 1 if $lines < 1;
 
    if($lines > input_end() - input_start() + 1) {
@@ -4509,7 +4509,7 @@ sub input_onscreen
 
    $plen = ansi_length(prompt()) + 1 if(has_prompt());
    my $start = @state{input_offset} * (@state{size_y} -1);
-   my $end  = $start + ((@state{size_y} - 1) * input_size());
+   my $end  = $start + ((@state{size_y} - 1) * input_size()) - $plen;
    loggit("input_onscreen[$plen]: $start -> $end == $pos");
    if($pos >= $start && $pos < $end) {
       return 1;                          # pos is in the input scroll region


### PR DESCRIPTION
## Summary
- Fixed `input_onscreen()`: `$plen` was calculated but never used, causing incorrect visible area calculation when prompts are displayed
- Fixed `update_input_offset()`: Changed `>= 0` to `> 0` in modulo condition (the original was always true, causing cursor positioning issues)

## Test plan
- [ ] Test keyboard input with a MUD that sends prompts
- [ ] Verify cursor positioning when typing long input that wraps
- [ ] Verify input display when scrolling through input history

🤖 Generated with [Claude Code](https://claude.com/claude-code)